### PR TITLE
Avoid false negative in CSRF 2

### DIFF
--- a/src/main/java/de/rub/nds/oidc/server/op/DefaultOP.java
+++ b/src/main/java/de/rub/nds/oidc/server/op/DefaultOP.java
@@ -218,6 +218,10 @@ public class DefaultOP extends AbstractOPImplementation {
 		return authReq.getState();
 	}
 
+	protected Nonce getNonce(AuthenticationRequest authReq) {
+		return authReq.getNonce();
+	}
+
 	@Override
 	public void authRequest(RequestPath path, HttpServletRequest req, HttpServletResponse resp) throws IOException {
 		logger.log("Authentication requested.");
@@ -229,7 +233,7 @@ public class DefaultOP extends AbstractOPImplementation {
 
 			URI redirectUri = authReq.getRedirectionURI();
 			State state = getState(authReq);
-			Nonce nonce = authReq.getNonce();
+			Nonce nonce = getNonce(authReq);
 			ResponseType responseType = authReq.getResponseType();
 
 			try {


### PR DESCRIPTION
I am testing a client and it is passing CSRF 2, where you use the state from another session.

However, the test log shows that the client is not rejecting the authentication response but is rejecting the token response. Checking the source code of the client reveals that it is saving the state, but in a global table and not tied to the session.  Thus accepting the state value when it is returned by another session. It then goes ahead and request the token, but will reject it because it has a nonce that does not match the one used for the given state (similar to Replay Attack 5). 

The test description says that an attack is successful if "the next protocol steps are executed". PrOfESSOS will not check for this, but will just monitor if the user has been logged in or not.

To avoid false negative, shouldn't PrOfESSOS also save and use the nonce from the previous session?